### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This is a simple example of how to use a [Fireproof](https://fireproof.storage/)
 
 This demo server implements a basic JSON document store with CRUD operations (Create, Read, Update, Delete) and the ability to query documents sorted by any field.
 
+<a href="https://glama.ai/mcp/servers/1p6uu10u9a"><img width="380" height="200" src="https://glama.ai/mcp/servers/1p6uu10u9a/badge" alt="mcp-database-server MCP server" /></a>
+
 # Installation
 
 Install dependencies:


### PR DESCRIPTION
This PR adds a badge for the mcp-database-server server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/1p6uu10u9a"><img width="380" height="200" src="https://glama.ai/mcp/servers/1p6uu10u9a/badge" alt="mcp-database-server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.